### PR TITLE
Rename 'Ghast Tear' to 'Raindrop'

### DIFF
--- a/assets/minecraft/lang/en_OC.lang
+++ b/assets/minecraft/lang/en_OC.lang
@@ -1,4 +1,3 @@
-
 language.name=English
 language.region=US
 language.code=en_OC
@@ -841,7 +840,7 @@ item.shears.name=Shears
 item.rottenFlesh.name=Rotten Flesh
 item.enderPearl.name=Ender Pearl
 item.blazeRod.name=Blaze Rod
-item.ghastTear.name=Ghast Tear
+item.ghastTear.name=Raindrop
 item.netherStalkSeeds.name=Nether Wart
 item.potion.name=Potion
 item.emptyPotion.name=Water Bottle


### PR DESCRIPTION
Change `Ghast Tear` to `Raindrop` in favor of the new [Raindrops feature](https://oc.tc/forums/topics/52a55a9eaf7fb080d2000002). Also #39.
