### PR TITLE
Add 1.7 blocks and fix block names in Natural Textures

### DIFF
--- a/assets/minecraft/optifine/natural.properties
+++ b/assets/minecraft/optifine/natural.properties
@@ -47,7 +47,6 @@ leaves_spruce=2F
 leaves_spruce_opaque=2F
 # Snow
 snow=4F
-snow_side=F
 grass_side_snowed=F
 # Cactus side
 cactus_side=2F


### PR DESCRIPTION
I added the new planks and leaves to Natural Textures, and fixed the names for the blocks that had their "old" names, so they will work.
