### PR TITLE
Update natural textures to support some 1.8 blocks

### DIFF
--- a/assets/minecraft/optifine/natural.properties
+++ b/assets/minecraft/optifine/natural.properties
@@ -13,8 +13,12 @@ grass_side=F
 grass_side_overlay=F
 # Stone
 stone=2F
+stone_diorite=2F
+stone_andesite=2F
+stone_granite=2F
 # Dirt
 dirt=4F
+coarse_dirt=4F
 # Slab
 stone_slab_top=F
 # Bedrock
@@ -70,6 +74,8 @@ end_stone=4
 # Sandstone
 sandstone_top=4
 sandstone_bottom=4F
+red_sandstone_top=4F
+red_sandstone_bottom=4F
 # Podzol
 dirt_podzol_top=4F
 dirt_podzol_side=F


### PR DESCRIPTION
This adds "missing" 1.8 blocks to natural textures;

- Since you have `stone`, I added `diorite`, `andesite` and `granite` to use the same properties of `stone`
- Since you have `dirt`, and `coarse_dirt` even looks the same, I added same properties to that.
- You have `sandstone`, so I added support do `red_sandstone`.